### PR TITLE
Use relative URLs to post, pages, archives and assets

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -6,8 +6,7 @@ description: Coding & Design for the rainy days
 
 # Your website URL
 # Used for Sitemap.xml and your RSS feed
-#url: https://www.demainilpleut.fr/
-url: http://192.168.99.1:8080
+url: https://www.demainilpleut.fr/
 
 # Number of post to display on the front page
 paginate: 2

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -6,23 +6,23 @@
         <h3 class="black">Latest posts</h3>
         <ul>
           {% for post in site.posts limit:5 %}
-            <li><a href="{{ site.baseurl }}{{ post.url }}" class="footer-link" title="{{ post.title }}">{{ post.title | truncate: 60, '...' }}</a></li>
+            <li><a href="/{{ post.url }}" class="footer-link" title="{{ post.title }}">{{ post.title | truncate: 60, '...' }}</a></li>
           {% endfor %}
         </ul>
       </div><!-- end of column -->
       <div class="column third">
         <h3 class="black">Menu</h3>
         <ul>
-          <li><a href="{{ site.url }}" class="footer-link">Blog</a></li>
-          <li><a href="{{ site.url }}/archives'" class="footer-link">Archives</a></li>
-          <li><a href="{{ site.url }}/styleguide" class="footer-link">Styleguide</a></li>
+          <li><a href="/" class="footer-link">Blog</a></li>
+          <li><a href="/archives" class="footer-link">Archives</a></li>
+          <li><a href="/styleguide" class="footer-link">Styleguide</a></li>
         </ul>
       </div><!-- end of column -->
       <div class="column third">
         <h3 class="black">Categories</h3>
         <ul>
         {% for category in site.categories limit:8 %}
-          <li><a href="{{ site.url }}/{{ category | first | downcase | replace: ' ', '_'  }}" class="footer-link">{{ category | first }} ({{ category | last | size }})</a></li>
+          <li><a href="/archives/{{ category | first | downcase | replace: ' ', '-'  }}" class="footer-link">{{ category | first }} ({{ category | last | size }})</a></li>
         {% endfor %}
         </ul>
       </div><!-- end of column -->

--- a/_includes/topbar.html
+++ b/_includes/topbar.html
@@ -1,15 +1,15 @@
 
 <div class="topbar bg-purple--light">
   <div class="topbar-logo">
-    <a href="{{site.url}}" class="topbar-logo-url">{{site.name}}</a>
+    <a href="/" class="topbar-logo-url">{{site.name}}</a>
   </div><!-- end of topBar logo -->
   <div class="topbar-menu">
     <button class="topbar-menu-btn topbar-menu-btn--small">Menu</button>
       <nav id="js-menu" role="navigation" class="topbar-navigation">
         <ul>
-          <li><a href="{{ site.url }}" class="topbar-navigation-item">Home</a></li>
-          <li><a href="{{ site.url }}/archives" class="topbar-navigation-item">Archives</a></li>
-          <li><a href="{{ site.url }}/styleguide" class="topbar-navigation-item">Styleguide</a></li>
+          <li><a href="/" class="topbar-navigation-item">Home</a></li>
+          <li><a href="/archives" class="topbar-navigation-item">Archives</a></li>
+          <li><a href="/styleguide" class="topbar-navigation-item">Styleguide</a></li>
         </ul>
       </nav><!-- end of topBarNavigation -->
   </div><!-- end of topBarMenu -->

--- a/_layouts/archives-category.html
+++ b/_layouts/archives-category.html
@@ -7,11 +7,11 @@ layout: default
 <div class="archives">
   <ul class="list-unordered">
   {% for post in page.posts %}
-  <li><a href="{{ post.url | prepend: site.baseurl }}" class="archives-link">{{ post.title }}</a><span class="archives-complement">&mdash;{{ post.date | date: '%B %d, %Y' }} at {{ post.published_at | date: "%R" }}</span></li>
+  <li><a href="{{ post.url }}" class="archives-link">{{ post.title }}</a><span class="archives-complement">&mdash;{{ post.date | date: '%B %d, %Y' }} at {{ post.published_at | date: "%R" }}</span></li>
   {% endfor %}
   </ul>
 </div>
 
 <div class="archives archives-return-link">
-  <a href="{{ site.baseurl }}/archives" class="archives-link">&larr; Return to archives</a>
+  <a href="/archives" class="archives-link">&larr; Return to archives</a>
 </div>

--- a/_layouts/archives-month.html
+++ b/_layouts/archives-month.html
@@ -5,7 +5,7 @@ layout: default
 <h1>Archives for {{ page.date | date: "%B %Y" }}</h1>
 
 <div class="archives archives-return-link">
-  <a href="{{ site.baseurl }}/archives" class="archives-link">&larr; Return to archives</a>
+  <a href="/archives" class="archives-link">&larr; Return to archives</a>
 </div>
 
 <div class="posts">
@@ -13,18 +13,18 @@ layout: default
    <!-- Look the author details up from the site config. -->
     {% assign author = site.data.authors[post.author] %}
     <article class="article">
-      <h2><a href="{{ site.baseurl }}{{ post.url }}" class="article-title">{{ post.title }}</a></h2>
-      <span class="article-author"><a class="article-author--link" href="{{ site.url }}/author/{{ author.handle }}/">{{ author.name }}</a></span>
+      <h2><a href="{{ post.url }}" class="article-title">{{ post.title }}</a></h2>
+      <span class="article-author"><a class="article-author--link" href="/author/{{ author.handle }}/">{{ author.name }}</a></span>
       <span class="article-pubdate">—&nbsp;<time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: '%B %d, %Y' }} at {{ post.published_at | date: "%R" }}</time></span>
       <div class="article-summary"></div>
       <p>
         {{ post.excerpt || strip_links || strip_imgs }}
       </p>
-      <div class="article-footer"><a class="btn bg-magenta white" href="{{ site.baseurl }}{{ post.url }}">Read more…</a></div>
+      <div class="article-footer"><a class="btn bg-magenta white" href="{{ post.url }}">Read more…</a></div>
     </article>
   {% endfor %}
 </div>
 
 <div class="archives archives-return-link">
-  <a href="{{ site.baseurl }}/archives" class="archives-link">&larr; Return to archives</a>
+  <a href="/archives" class="archives-link">&larr; Return to archives</a>
 </div>

--- a/_layouts/archives-year.html
+++ b/_layouts/archives-year.html
@@ -5,7 +5,7 @@ layout: default
 <h1>Archives for {{ page.date | date: "%Y" }}</h1>
 
 <div class="archives archives-return-link">
-  <a href="{{ site.baseurl }}/archives" class="archives-link">&larr; Return to archives</a>
+  <a href="/archives" class="archives-link">&larr; Return to archives</a>
 </div>
 
 <div class="posts">
@@ -33,5 +33,5 @@ layout: default
 </div>
 
 <div class="archives archives-return-link">
-  <a href="{{ site.baseurl }}/archives" class="archives-link">&larr; Return to archives</a>
+  <a href="/archives" class="archives-link">&larr; Return to archives</a>
 </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -7,15 +7,15 @@
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
   <meta name="description" content="{{ site.description }}">
   <link rel="dns-prefetch" href="https://fonts.googleapis.com">
-  <link rel="stylesheet" type="text/css" href="{{ site.url }}/css/style.css" />
-  <link rel="stylesheet" type="text/css" href="{{ site.url }}/css/prism.min.css" />
+  <link rel="stylesheet" type="text/css" href="/css/style.css" />
+  <link rel="stylesheet" type="text/css" href="/css/prism.min.css" />
   <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
   <link rel="icon" type="image/png" href="/img/favicon-196.png" sizes="196x196" />
   <link rel="icon" type="image/png" href="/img/favicon-96.png" sizes="96x96" />
   <link rel="icon" type="image/png" href="/img/favicon-32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="/img/favicon-16.png" sizes="16x16" />
   <link rel="icon" type="image/png" href="/img/favicon-128.png" sizes="128x128" />
-  <script src="{{ site.url }}/js/picturefill.min.js"></script>
+  <script src="/js/picturefill.min.js"></script>
 </head>
   <body>
     <!-- wrapper -->
@@ -31,8 +31,8 @@
     </div><!-- end of wrapper -->
 
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=blissfuljs"></script>
-    <script src="{{ site.url }}/js/bliss.min.js"></script>
-    <script src="{{ site.url }}/js/prism.min.js"></script>
+    <script src="/js/bliss.min.js"></script>
+    <script src="/js/prism.min.js"></script>
     <script>
       // Add/display the mobile menu button, and
       $.ready().then(function() {

--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -11,7 +11,7 @@ layout: default
 
   <article class="article">
     {% if author %}
-    <span class="article-author">by&nbsp;<a class="article-author--link" href="{{ site.url}}/authors/{{ author.handle }}">{{ author.name }}</a></span>
+    <span class="article-author">by&nbsp;<a class="article-author--link" href="/authors/{{ author.handle }}">{{ author.name }}</a></span>
     {% endif %}
     <span class="article-pubdate">&mdash;&nbsp;<time datetime="{{ page.date | date_to_xmlschema }}">{{ page.date | date: '%B %d, %Y' }} at {{ page.published_at | date: "%R" }}</time></span>
     <div class="article-summary">
@@ -31,7 +31,7 @@ layout: default
       Published in
       {% assign total_cat = page.categories.size %}
       {% for category in page.categories %}
-        <a href="{{ site.url }}/archives/{{ category | downcase | replace: ' ', '-'  }}" class="footer-link">{{ category }}</a>
+        <a href="/archives/{{ category | downcase | replace: ' ', '-'  }}" class="footer-link">{{ category }}</a>
         {% if forloop.last == false %}
         ,
         {% endif %}
@@ -45,8 +45,8 @@ layout: default
     <h2 class="about-title">About the Author</h2>
     <div class="about-author">
       <div class="about-author-bio">
-      <a class="about-author-avatar" href="{{ site.url}}/authors/{{ author.handle }}"><img src="{{ author.avatar }}" width="80" height="80" alt=""></a>
-        <p><span class="about-author-name"><a href="{{ site.url}}/authors/{{ author.handle }}">{{ author.name }}</a></span><br><small>{{ author.description }}</small></p>
+      <a class="about-author-avatar" href="/authors/{{ author.handle }}"><img src="{{ author.avatar }}" width="80" height="80" alt=""></a>
+        <p><span class="about-author-name"><a href="/authors/{{ author.handle }}">{{ author.name }}</a></span><br><small>{{ author.description }}</small></p>
       </div><!-- end of author bio -->
     </div><!-- end of about author -->
   </div><!-- end of about section -->

--- a/archives/index.html
+++ b/archives/index.html
@@ -11,7 +11,7 @@ Welcome to the archives. Here you can find all of the posts made over the years,
   <ol class="list-ordered" start="1" type="1">
     {% for post in site.posts limit:10 offset:1 %}
     <li>
-      <a href="{{ post.url | prepend: site.baseurl }}" class="archives-link">{{ post.title }}</a>
+      <a href="{{ post.url }}" class="archives-link">{{ post.title }}</a>
     </li>
     {% endfor %}
   </ol>
@@ -21,7 +21,7 @@ Welcome to the archives. Here you can find all of the posts made over the years,
 <div class ="archives">
   <ul class="list-unordered">
   {% for category in site.categories %}
-    <li><a href="{{ site.url }}/archives/{{ category | first | downcase | replace: ' ', '-'  }}" class="archives-link">{{ category | first }}</a><span class="archives-complement">({{ category | last | size }})</span></li>
+    <li><a href="/archives/{{ category | first | downcase | replace: ' ', '-'  }}" class="archives-link">{{ category | first }}</a><span class="archives-complement">({{ category | last | size }})</span></li>
   {% endfor %}
   </ul>
 </div>

--- a/index.html
+++ b/index.html
@@ -4,16 +4,19 @@ layout: default
 
 <div class="posts">
   {% for post in paginator.posts %}
+
+    <!-- Look the author details up from the site config. -->
+    {% assign author = site.data.authors[post.author] %}
     <article class="article">
 
-      <h2><a href="{{ site.baseurl }}{{ post.url }}" class="article-title">{{ post.title }}</a></h2>
-      <span class="article-author"><a class="article-author--link" href="https://www.demainilpleut.fr/author/jveillet/">Jérémie Veillet</a></span>
+      <h2><a href="{{ post.url }}" class="article-title">{{ post.title }}</a></h2>
+      <span class="article-author"><a class="article-author--link" href="/authors/{{ author.handle }}">{{ author.name }}</a></span>
       <span class="article-pubdate">—&nbsp;<time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: '%B %d, %Y' }} at {{ post.published_at | date: "%R" }}</time></span>
       <div class="article-summary"></div>
       <p>
         {{ post.excerpt || strip_links || strip_imgs }}
       </p>
-      <div class="article-footer"><a class="btn bg-magenta white" href="{{ site.baseurl }}{{ post.url }}">Read more…</a></div>
+      <div class="article-footer"><a class="btn bg-magenta white" href="{{ post.url }}">Read more…</a></div>
     </article>
   {% endfor %}
 </div>
@@ -22,21 +25,21 @@ layout: default
 <div class="pagination">
   <ul class="page-numbers">
     {% if paginator.previous_page %}
-      <li><a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="page-numbers previous">&laquo; Prev</a></li>
+      <li><a href="{{ paginator.previous_page_path | prepend: '/' | replace: '//', '/' }}" class="page-numbers previous">&laquo; Prev</a></li>
     {% endif %}
 
     {% for page in (1..paginator.total_pages) %}
       {% if page == paginator.page %}
         <li><span class="page-numbers current">{{ page }}</span></li>
       {% elsif page == 1 %}
-        <li><a href="{{ paginator.previous_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="page-numbers">{{ page }}</a></li>
+        <li><a href="{{ paginator.previous_page_path | prepend: '/' | replace: '//', '/' }}" class="page-numbers">{{ page }}</a></li>
       {% else %}
-        <li><a href="{{ site.paginate_path | prepend: site.baseurl | replace: '//', '/' | replace: ':num', page }}" class="page-numbers">{{ page }}</a></li>
+        <li><a href="{{ site.paginate_path | prepend: '/' | replace: '//', '/' | replace: ':num', page }}" class="page-numbers">{{ page }}</a></li>
       {% endif %}
     {% endfor %}
 
     {% if paginator.next_page %}
-      <li><a href="{{ paginator.next_page_path | prepend: site.baseurl | replace: '//', '/' }}" class="page-numbers next">Next &raquo;</a></li>
+      <li><a href="{{ paginator.next_page_path | prepend: '/' | replace: '//', '/' }}" class="page-numbers next">Next &raquo;</a></li>
     {% endif %}
   </ul>
 </div>


### PR DESCRIPTION
Fixed relatives URLs to pages, posts, archives instead of a varial in the _config.yml.
Changed in the authors URL (not existing yet).