### PR TITLE
[FIX] Move Picurefill outside of the floating point

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -17,7 +17,6 @@
   <link rel="icon" type="image/png" href="/img/favicon-32.png" sizes="32x32" />
   <link rel="icon" type="image/png" href="/img/favicon-16.png" sizes="16x16" />
   <link rel="icon" type="image/png" href="/img/favicon-128.png" sizes="128x128" />
-  <script src="/js/picturefill.min.js"></script>
 </head>
   <body>
     <!-- wrapper -->
@@ -34,6 +33,7 @@
 
     <link rel="stylesheet" type="text/css" href="/css/prism.min.css" />
     <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js"></script>
+    <script src="/js/picturefill.min.js"></script>
     <script src="https://cdn.polyfill.io/v2/polyfill.min.js?features=blissfuljs"></script>
     <script src="/js/bliss.min.js"></script>
     <script src="/js/prism.min.js"></script>


### PR DESCRIPTION
* Picturefill is positioned with the other JS resources at the bottom of the page, to speed loading of the page (as pointed by Google PageSpeed index).

https://trello.com/c/ipUbLqk0