### PR TITLE
[ISSUE-43] Change Dockerfile build process

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,14 +1,8 @@
-bundler:
-  image: heroku/heroku:16-build
-  volumes:
-    - /bundle
-
-blog:
+web:
   build: .
+  env_file: .env
   ports:
     - "8080:4000"
   volumes:
-    - .:/app
-  volumes_from:
-    - bundler
-  command: bundle exec jekyll serve -H 0.0.0.0
+    - .:/home/app
+  command: bundle exec jekyll serve -H 0.0.0.0 --incremental

--- a/package.json
+++ b/package.json
@@ -15,14 +15,14 @@
   "bugs": {
     "url": "https://github.com/jveillet/jk-demainilpleut/issues"
   },
-  "homepage": "https://github.com/jveillet/jk-demainilpleut#readme",
+  "homepage": "https://github.com/jveillet/jk-demainilpleut#README.md",
   "devDependencies": {
-    "postcss": "^6.0.11",
-    "autoprefixer": "^7.1.4",
-    "gulp": "^3.9.1",
+    "postcss": "^6.0.16",
+    "autoprefixer": "^7.2.5",
+    "gulp": "^v4.0.0",
     "gulp-cssnano": "^2.1.2",
-    "gulp-postcss": "^7.0.0",
+    "gulp-postcss": "^7.0.1",
     "gulp-rename": "^1.2.2",
-    "gulp-sourcemaps": "^2.6.1"
+    "gulp-sourcemaps": "^2.6.4"
   }
 }


### PR DESCRIPTION
Fixes #43 .

+ Updated docker-compose file to not use an extra container for bundler.
+ Update npm dependencies.
+ We use now a non-root user to use the container.
+ Heroku-16 is the default image istead of Heroku-16-build.
+ Added Gulp CLI ito use the new way of using gulp.
+ Jekyll now build incrementaly when starting docker-compose up.
+ Container is now named "web".
