### PR TITLE
[ISSUE-54] Add Stylelint to lint CSS

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -1,0 +1,26 @@
+{
+  "rules": {
+    "block-no-empty": true,
+    "color-hex-case": "lower",
+    "color-hex-length": "long",
+    "color-no-invalid-hex": true,
+    "font-family-name-quotes": "always-where-recommended",
+    "font-family-no-duplicate-names": true,
+    "font-family-no-missing-generic-family-keyword": true,
+    "function-calc-no-unspaced-operator": true,
+    "function-linear-gradient-no-nonstandard-direction": true,
+    "function-whitespace-after": "always",
+    "indentation": 2,
+    "length-zero-no-unit": true,
+    "number-leading-zero": "never",
+    "number-no-trailing-zeros": true,
+    "selector-no-vendor-prefix": true,
+    "shorthand-property-no-redundant-values": true,
+    "string-no-newline": true,
+    "string-quotes": "double",
+    "unit-case": "lower",
+    "unit-no-unknown": true,
+    "unit-whitelist": ["em", "rem", "%", "s", "vh", "vw", "ms"],
+    "value-no-vendor-prefix": true
+  }
+}

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -19,3 +19,15 @@ gulp.task('default', function() {
         .pipe(sourcemaps.write('.'))
         .pipe(gulp.dest(CSS_DEST));
 });
+
+gulp.task('lint-css', function lintCssTask() {
+  const gulpStylelint = require('gulp-stylelint');
+
+  return gulp
+    .src('css/style-dark.css')
+    .pipe(gulpStylelint({
+    reporters: [
+      {formatter: 'string', console: true}
+    ]
+  }));
+});

--- a/package.json
+++ b/package.json
@@ -23,6 +23,8 @@
     "gulp-cssnano": "^2.1.2",
     "gulp-postcss": "^7.0.1",
     "gulp-rename": "^1.2.2",
-    "gulp-sourcemaps": "^2.6.4"
+    "gulp-sourcemaps": "^2.6.4",
+    "stylelint": "^8.3.0",
+    "gulp-stylelint": "^6.0.0"
   }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
To enforce good practices and to have a common styling guide of CSS, I had the CSS linter Stylelint to the project. We can launch it by executing the Gulp task lint-css.
There is a basic .stylintrc file with basic rules. Let's make it evolve over time.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
#54 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change is needed to a common styling practice on the CSS code base.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
`npm gulp lint-css`

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
