### PR TITLE
[BUG] Jekyll build is crashing with an invalid date format

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -40,6 +40,7 @@ exclude:
   - package-lock.json
   - package.json
   - styles
+  - vendor
 
 # Display drafts
 show_drafts: true


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Re-add the exclusion of "vendor" folders into the config file of Jekyll.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
https://github.com/jekyll/jekyll/issues/2938

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Jekyll is failing the build of the site for an invalid date, it tries to build a post from a vendor folder starting with "00-00-0000".

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
bundle exec jekyll build

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
