### PR TITLE
[ISSUE-82] Regroup posts cards into a single list on the landing page

### DIFF
--- a/_layouts/post.html
+++ b/_layouts/post.html
@@ -44,7 +44,7 @@ layout: default
     <h2 class="about-title">About the Author</h2>
     <div class="about-author">
       <div class="about-author-bio">
-      <a class="about-author-avatar" href="/authors/{{ author.handle }}"><img src="{{ author.avatar }}" width="80" height="80" alt=""></a>
+      <a class="about-author-avatar" href="/authors/{{ author.handle }}"><img src="{{ author.avatar }}" width="80" height="80" alt="{{ author.handle }}"></a>
         <p><span class="about-author-name"><a href="/authors/{{ author.handle}}"
             class="primary-link">{{ author.name }}</a></span><br><small class="about-author-description">{{ author.description }}</small></p>
         <ul class="social">

--- a/index.html
+++ b/index.html
@@ -7,24 +7,26 @@ layout: default
 
     <!-- Look the author details up from the site config. -->
     {% assign author = site.data.authors[post.author] %}
-    <article class="article">
+    <article class="articles">
       <h2><a href="{{ post.url }}" class="article-title">{{ post.title }}</a></h2>
-      <span class="article-author"><a class="article-author--link" href="/authors/{{ author.handle }}">{{ author.name }}</a></span>
-      <span class="article-pubdate">—&nbsp;<time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: '%B %d, %Y' }} at {{ post.published_at | date: "%R" }}</time></span>
-      <div class="article-summary"></div>
       <div class="article-excerpt">
         {{ post.excerpt | strip_links | strip_imgs }}
       </div>
-      <div class="article-footer"><a class="btn bg-blue white" href="{{ post.url }}">Read more…</a></div>
-      <div class="article-tags">
-        {% assign total_cat = post.categories.size %}
-        {% for category in post.categories %}
-          <span class="article-tags-item">
-            <a href="/archives/{{ category | downcase | replace: ' ', '-'  }}"
-              class="article-tags-link">{{ category }}</a>
-          </span>
-        {% endfor %}
-      </div>
+      <div class="articles-footer">
+        <div class="articles-footer-wrapper">
+          <img src="{{ author.avatar }}" width="32" height="32" alt="{{ author.name }}" class="articles-footer-avatar">
+          <span style="article-author"><a class="article-author--link" href="/authors/{{ author.handle }}">{{ author.name }}</a></span>
+          <span class="article-pubdate"> on <time datetime="{{ post.date | date_to_xmlschema }}">{{ post.date | date: '%B %d, %Y' }}</time></span>
+          <div class="articles-footer-tags">
+            {% assign total_cat = post.categories.size %}
+            {% for category in post.categories %}
+              <span class="article-tags-item">
+                <a href="/archives/{{ category | downcase | replace: ' ', '-'  }}" class="article-tags-link">{{ category }}</a>
+              </span>
+            {% endfor %}
+          </div><!-- end of articles footer tags -->
+        </div><!-- end of articles footer wrapper -->
+      </div><!-- end of articles footer -->
     </article>
   {% endfor %}
 </div>

--- a/styles/post/post.css
+++ b/styles/post/post.css
@@ -161,7 +161,7 @@ Use it to make something cool, have fun, and share what you've learned with othe
 .article-tags {
   font-size: .8em;
   font-weight: 600;
-  width: 100%
+  width: 100%;
 }
 
 .article-tags-item {

--- a/styles/post/post.css
+++ b/styles/post/post.css
@@ -20,6 +20,47 @@ Use it to make something cool, have fun, and share what you've learned with othe
   padding: 2em;
 }
 
+.articles {
+  background-color: #ffffff;
+  padding: 2em;
+  border-bottom: .0625em solid #f1f1f1;
+}
+
+.articles:first-child {
+  margin-top: 1em;
+  border-radius: .2em .2em 0 0;
+}
+
+.articles:last-child {
+  margin-bottom: 1em;
+  border-radius: 0 0 .2em .2em;
+  border-bottom: 0;
+}
+
+.articles-footer {
+  margin-top: 3em;
+}
+
+.articles-footer-wrapper {
+  display: flex;
+  align-items: center;
+  flex-flow: row wrap;
+  flex-direction: column;
+  justify-content: flex-start;
+}
+
+.articles-footer-avatar {
+  border-radius: 100%;
+  margin-right: .5em;
+}
+
+.articles-footer-tags {
+  font-size: .9em;
+  display: inline;
+  font-weight: 600;
+  margin: 0;
+}
+
 .primary-link,
 .primary-link:visited{
   color: #0a0000;
@@ -79,8 +120,9 @@ Use it to make something cool, have fun, and share what you've learned with othe
 
 .article-pubdate {
   color: #aeb0b5;
-  font-size: .8em;
+  margin: 0;
   font-style: italic;
+  font-size: 1em;
 }
 
 .article-categories {
@@ -119,7 +161,7 @@ Use it to make something cool, have fun, and share what you've learned with othe
 .article-tags {
   font-size: .8em;
   font-weight: 600;
-  width: 100%;
+  width: 100%
 }
 
 .article-tags-item {
@@ -159,6 +201,21 @@ Use it to make something cool, have fun, and share what you've learned with othe
 
 @media all and (min-width: 47em) {
 
+  .articles-footer-wrapper {
+    display: flex;
+    align-items: center;
+    flex-flow: row wrap;
+    flex-direction: row;
+    justify-content: flex-start;
+  }
+
+  .articles-footer-tags {
+    font-size: .9em;
+    display: inline;
+    font-weight: 600;
+    margin-left: 3em;
+  }
+
   .article-wrapper {
     margin: 0 auto;
     width: 45.5em;
@@ -180,6 +237,13 @@ Use it to make something cool, have fun, and share what you've learned with othe
 
   .article-tags-item {
     margin-top: 0;
+  }
+
+  .article-pubdate {
+    color: #aeb0b5;
+    margin-left: .5em;
+    font-size: 1em;
+    font-style: italic;
   }
 
   .article-top {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->
Redesign the UI of the posts list on the Home page.
Remove list of cards.
Add a list view separated by a light gray line.
Remove the Read More button.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
resolve #82 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
To make the Home page more readable and better looking.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox, Chrome and Edge (Windows).

## Screenshots (if appropriate):
![screenshot-home-page](https://user-images.githubusercontent.com/5037407/44098408-772a5710-9fe0-11e8-9ae8-1df535c9da1f.jpg)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
