### PR TITLE
[ISSUE-103] Change tags display on the footer

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
 ruby '2.3.1'

--- a/Rakefile
+++ b/Rakefile
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 namespace :assets do
   task :precompile do
     puts `JEKYLL_ENV=production bundle exec jekyll build`

--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -23,7 +23,7 @@
         <h3 class="black">Categories</h3>
         <ul>
         {% for category in site.categories limit:8 %}
-          <li><a href="/archives/{{ category | first | downcase | replace: ' ', '-'  }}" class="footer-link">{{ category | first }} ({{ category | last | size }})</a></li>
+          <li><span class="footer-hastgag">#</span><a href="/archives/{{ category | first | downcase | replace: ' ', '-'  }}" class="footer-link">{{ category | first }} ({{ category | last | size }})</a></li>
         {% endfor %}
         </ul>
       </div><!-- end of column -->

--- a/_plugins/environment_variables.rb
+++ b/_plugins/environment_variables.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'dotenv'
 
 Dotenv.load

--- a/_plugins/strip_html_tags.rb
+++ b/_plugins/strip_html_tags.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'liquid'
 
 ##
@@ -5,15 +7,16 @@ require 'liquid'
 # in the outpout of the articles excerpts.
 #
 module StripHtmlTags
+  EMPTY_STRING = ''
+
   def strip_links(input)
-    input.gsub(/<a([^>]+)>(.+?)<\/a>/mi) do
-      $2.to_s
+    input.gsub(%r{<a([^>]+)>(.+?)</a>}mi) do
+      Regexp.last_match(2)
     end
   end
 
   def strip_imgs(input)
-    empty = ''.freeze
-    input.gsub(/<img\s?.*?\/?>/mi, empty)
+    input.gsub(%r{<img\s?.*?\/?>}mi, EMPTY_STRING)
   end
 end
 

--- a/config.ru
+++ b/config.ru
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 require 'rack/jekyll'
 require 'yaml'
 

--- a/styles/footer/footer.css
+++ b/styles/footer/footer.css
@@ -44,3 +44,8 @@ Use it to make something cool, have fun, and share what you've learned with othe
 .footer-link:hover {
   text-decoration: underline;
 }
+
+.footer-hastgag {
+  color: #205493;
+  font-weight: bold;
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Change display of tags in the footer  with a visible # and a different color
Fix Rubocop issues.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #103

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We want to be able to see straight away the tags in the footer.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with firefox.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
