### PR TITLE
[ISSUE-104] Add a link to RSS/Atom feed in the footer

### DIFF
--- a/_includes/footer.html
+++ b/_includes/footer.html
@@ -16,6 +16,7 @@
           <li><a href="/" class="footer-link">Home</a></li>
           <li><a href="/archives" class="footer-link">Archives</a></li>
           <li><a href="/authors" class="footer-link">Authors</a></li>
+          <li><a href="/feed.xml" class="footer-link">RSS feed</a></li>
           <li><a href="/styleguide" class="footer-link">Styleguide</a></li>
         </ul>
       </div><!-- end of column -->


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add a link to the RSS/Atom feed in the footer of the website

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #104

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Small enhancement to add a visual link to the Atom feed on the footer of the website, previously you had
to type it in the URL (I don't think browsers advertise anymore an RSS feed by the appropriate meta tag).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox, click on the link and the feeds displays.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [x] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
