### PR TITLE
[ISSUE-119] Override the site URL at build time

### DIFF
--- a/_plugins/environment_variables.rb
+++ b/_plugins/environment_variables.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
-require 'dotenv'
-
-Dotenv.load
+require 'dotenv/load'
 
 module Jekyll
   ##
@@ -14,6 +12,13 @@ module Jekyll
       site.config['google_analytics'] = ENV['GA_TRACKING_ID']
       # Add other environment variables to `site.config` here...
       site.config['cdn'] = ENV['S3_IMG_BUCKET_URL']
+      # Override the site URL, mainly for development purposes
+      site.config['url'] = ENV['SITE_URL'] if override_site_url?
+    end
+
+    def override_site_url?
+      return false unless ENV['OVERRIDE_SITE_URL']
+      ENV['OVERRIDE_SITE_URL'].to_s == 'true'
     end
   end
 end


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add env variables to override the site URL at build time.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #119 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It solves development and test on QA instance, as we can override the `site.url` at build time and use the actual URL we want to test.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with the command `jekyll serve` and `jekyll build`.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (a non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
