### PR TITLE
[ISSUE-129] Change configuration of bundler with Docker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,6 +7,8 @@ ENV RACK_ENV=development
 ENV JEKYLL_ENV=development
 ENV BUNDLE_APP_CONFIG=$APP_HOME/.bundle/
 ENV BUNDLE_JOBS=10
+ENV GEM_HOME="/usr/local/bundle"
+ENV PATH $GEM_HOME/bin:$GEM_HOME/gems/bin:$PATH
 
 # Create the home directory for the new app user.
 RUN mkdir -p $APP_HOME
@@ -63,4 +65,9 @@ RUN npm install
 
 EXPOSE 4000
 
-CMD ["bundle", "exec", "jekyll", "build"]
+RUN unset BUNDLE_PATH
+RUN unset BUNDLE_BIN
+
+ENTRYPOINT ["bundle", "exec"]
+
+CMD ["jekyll", "build"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,4 +8,4 @@ services:
       - "8080:4000"
     volumes:
       - .:/home/doctor/demainilpleut
-    command: bundle exec jekyll serve -H 0.0.0.0 --incremental
+    command: jekyll serve -H 0.0.0.0 --incremental


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Change the bundler env variables as documented in the Bundler website for Docker configuration.
Add entrypoint in the Dockerfile to point to `bundle exec`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #129 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fix issues when you have multiple gemfiles, and permit to call the needed gem directly instead of doing `bundle exec` every time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested successfully by building the image with `docker-compose build` and running it via `docker-compose up`.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (a non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
