### PR TITLE
[ISSUE-152] Add a stripe with multiple colors at the bottom of the top bar

### DIFF
--- a/.stylelintrc
+++ b/.stylelintrc
@@ -58,7 +58,7 @@
     "string-quotes": "double",
     "unit-case": "lower",
     "unit-no-unknown": true,
-    "unit-whitelist": ["em", "rem", "%", "s", "vh", "vw", "ms"],
+    "unit-whitelist": ["em", "rem", "%", "s", "vh", "vw", "ms", "deg"],
     "value-no-vendor-prefix": true
   }
 }

--- a/custom_css/topbar/topbar.css
+++ b/custom_css/topbar/topbar.css
@@ -14,12 +14,17 @@ Use it to make something cool, have fun, and share what you've learned with othe
 
 .topbar {
   background-color: #ffffff;
-  border-bottom: .0625em solid #f1f1f1;
   position: relative;
+  background-image: linear-gradient(90deg,#f2f5ff,#5b83fd 25%,#2c5efa 25%,#03e474 50%,#ed9c0a 25%,#f5eb16 75%,#fa2c39 25%,#0027d7 100%);
+  background-size: 100% .25em;
+  background-position: 50% 100%;
+  background-repeat: no-repeat;
 }
 
 .topbar.active {
   border-radius: 0 0 50% 50% / 0 0 25% 25%;
+  border-bottom: .0625em solid #f1f1f1;
+  background-image: none;
 }
 
 .topbar-logo-url,

--- a/package-lock.json
+++ b/package-lock.json
@@ -2387,13 +2387,11 @@
         },
         "balanced-match": {
           "version": "1.0.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
-          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -2406,18 +2404,15 @@
         },
         "code-point-at": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "concat-map": {
           "version": "0.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "console-control-strings": {
           "version": "1.1.0",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -2520,8 +2515,7 @@
         },
         "inherits": {
           "version": "2.0.3",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "ini": {
           "version": "1.3.5",
@@ -2531,7 +2525,6 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -2544,7 +2537,6 @@
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -2644,8 +2636,7 @@
         },
         "number-is-nan": {
           "version": "1.0.1",
-          "bundled": true,
-          "optional": true
+          "bundled": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2655,7 +2646,6 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2761,7 +2751,6 @@
         "string-width": {
           "version": "1.0.2",
           "bundled": true,
-          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add a custom background image at the bottom of the page with
multiple colors.
Modified stylelint file to whitelist "deg" unit.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #152

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This change introduces a little more spark of color for the blog, it breaks a little bit the monotonic tone of the UI.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox, Chrome, and Safari.

## Screenshots (if appropriate):
<img width="741" alt="image" src="https://user-images.githubusercontent.com/5037407/50689728-1e547380-102b-11e9-8599-52f7730bc9f9.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (a non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
