### PR TITLE
[ISSUE-158] Remove the type attribute on script and link tags

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,21 +18,21 @@
   <meta name="twitter:card"  content="summary">
   {% endif %}
   <meta name="theme-color" content="#ffffff"/>
-  <link href='{{ site.url }}/feed.xml' rel='alternate' type='application/atom+xml'>
+  <link href='{{ site.url }}/feed.xml' rel='alternate'>
   <link rel="dns-prefetch" href="https://fonts.googleapis.com">
-  <link media="screen" rel="stylesheet" type="text/css" href="{{ site.url}}/assets/css/bundle.min.css" />
-  <link media="screen" rel="stylesheet" type="text/css" href="{{ site.url}}/assets/css/vendor/prism.min.css" />
+  <link media="screen" rel="stylesheet" href="{{ site.url}}/assets/css/bundle.min.css" />
+  <link media="screen" rel="stylesheet" href="{{ site.url}}/assets/css/vendor/prism.min.css" />
   {% if jekyll.environment == 'production' %}
     {% assign img_url = site.url | append: '/assets/images' %}
   {% else %}
     {% assign img_url = site.url | append: '/assets/images/dev' %}
   {% endif %}
   <link rel="icon" href="{{ img_url }}/favicon.ico" />
-  <link rel="icon" type="image/png" href="{{ img_url }}/favicon-196.png" sizes="196x196" />
-  <link rel="icon" type="image/png" href="{{ img_url }}/favicon-96.png" sizes="96x96" />
-  <link rel="icon" type="image/png" href="{{ img_url }}/favicon-32.png" sizes="32x32" />
-  <link rel="icon" type="image/png" href="{{ img_url }}/favicon-16.png" sizes="16x16" />
-  <link rel="icon" type="image/png" href="{{ img_url }}/favicon-128.png" sizes="128x128" />
+  <link rel="icon" href="{{ img_url }}/favicon-196.png" sizes="196x196" />
+  <link rel="icon" href="{{ img_url }}/favicon-96.png" sizes="96x96" />
+  <link rel="icon" href="{{ img_url }}/favicon-32.png" sizes="32x32" />
+  <link rel="icon" href="{{ img_url }}/favicon-16.png" sizes="16x16" />
+  <link rel="icon" href="{{ img_url }}/favicon-128.png" sizes="128x128" />
   <link rel="manifest" href="{{ site.url }}/manifest.json">
 </head>
   <body>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove "type" attribute in `<link>` and `<script>` tags.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #158

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Having your CSS tags before any JavaScript enables better, parallel download which speeds up browser rendering time.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (a non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
