### PR TITLE
[ISSUE-179] Icons not displaying on authors page

### DIFF
--- a/authors/index.html
+++ b/authors/index.html
@@ -22,12 +22,12 @@ layout: default
       <div class="member-links">
           {% if member.twitter %}
           <a href="https://www.twitter.com/{{ member.twitter }}">
-            <img src="{{ site.url }}//assets/images/twitter.svg" width="32" height="32" alt="Twitter profile">
+            <img src="{{ site.url }}/assets/images/twitter.svg" width="32" height="32" alt="Twitter profile">
           </a>
           {% endif %}
           {% if member.web.link %}
           <a href="{{ member.web.link }}">
-            <img src="{{ site.url }}//assets/images/icon-web.svg" width="32" height="32" alt="Personal website: {{ member.web.handle }}">
+            <img src="{{ site.url }}/assets/images/icon-web.svg" width="32" height="32" alt="Personal website: {{ member.web.handle }}">
           </a>
           {% endif %}
         </a>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
emove doubled trailing slashes in the URLs of the Authors page links.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #179 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The icons don't appear on the Authors page, alt text is showing instead, this issue fixes this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [x] Bug fix (a non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
