### PR TITLE
[ISSUE-181] Weird character on the authors page

### DIFF
--- a/authors/index.html
+++ b/authors/index.html
@@ -4,8 +4,7 @@ layout: default
 
 <article class="article page-author">
   <h1>Authors</h1>
-  <div class="article-excerpt">Here is all the beautifull people that are
-    contributing to this blog. </div>
+  <div class="article-excerpt">Here is all the beautifull people that are contributing to this blog.</div>
 
   <div class="members-list">
     {% for author in site.data.authors %}
@@ -16,24 +15,23 @@ layout: default
     <div class="member">
       <div class="member-avatar">
         <a href="{{ site.url }}/authors/{{ member.handle }}">
-          <img src="{{ member.avatar }}" class="avatar avatar--size" alt="{{ member.name }}"><a href="{{ site.url }}/authors/{{ member.handle }}" class="primary-link">
+          <img src="{{ member.avatar }}" class="avatar avatar--size" alt="{{ member.name }}">
         </a>
       </div><!-- End of member-avatar -->
       <div class="member-links">
-          {% if member.twitter %}
-          <a href="https://www.twitter.com/{{ member.twitter }}">
-            <img src="{{ site.url }}/assets/images/twitter.svg" width="32" height="32" alt="Twitter profile">
-          </a>
-          {% endif %}
-          {% if member.web.link %}
-          <a href="{{ member.web.link }}">
-            <img src="{{ site.url }}/assets/images/icon-web.svg" width="32" height="32" alt="Personal website: {{ member.web.handle }}">
-          </a>
-          {% endif %}
+        {% if member.twitter %}
+        <a href="https://www.twitter.com/{{ member.twitter }}">
+          <img src="{{ site.url }}/assets/images/twitter.svg" width="32" height="32" alt="Twitter: @{{ member.twitter }}">
         </a>
+        {% endif %}
+        {% if member.web.link %}
+        <a href="{{ member.web.link }}">
+          <img src="{{ site.url }}/assets/images/icon-web.svg" width="32" height="32" alt="Personal website: {{ member.web.handle }}">
+        </a>
+        {% endif %}
       </div><!-- End of member-links -->
       <div class="member-name">
-          <div><a href="{{ site.url }}/authors/{{ member.handle }}" class="primary-link">{{ member.name }}</a></div>
+        <div><a href="{{ site.url }}/authors/{{ member.handle }}" class="primary-link">{{ member.name }}</a></div>
       </div><!-- End of member-name -->
       <div class="member-bio">
         <div class="article-excerpt">{{ member.description | truncate: 250, "..." }}</div>

--- a/custom_css/author/author.css
+++ b/custom_css/author/author.css
@@ -32,6 +32,10 @@ Description: Author section styles
   margin-bottom: .5em;
 }
 
+.member-links a {
+  text-decoration: none;
+}
+
 .member-name {
   font-size: 1.2em;
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Added a `text-decoration: none` on member links to avoid having images displaying a link.
Fixed wrong markup on links on the member's page (extra `<a>`s).

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #181 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Like described in the issue, there is a weird link appearing at the bottom of social images on the Authors page.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5037407/51463798-6f22d680-1d64-11e9-99f0-988d80779baf.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to
  change)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
