### PR TITLE
[ISSUE-167] Change tags background color on hover

### DIFF
--- a/custom_css/post/post.css
+++ b/custom_css/post/post.css
@@ -157,22 +157,23 @@ Description: Styles for articles / posts
 }
 
 .article-tags-item {
-  background-color: #f1f1f1;
-  border-radius: 5%;
-  display: inline-block;
   margin-right: .5em;
-  margin-top: .5em;
-  padding: .5em;
 }
 
 .article-tags-link:link,
 .article-tags-link:visited{
+  background-color: #f1f1f1;
+  border-radius: 5%;
   color: #494440;
+  display: inline-block;
+  margin-top: .5em;
+  padding: .5em;
   text-decoration: none;
 }
 
-.article-tags-link:hover{
-  text-decoration: underline;
+.article-tags-item .article-tags-link:hover{
+  background-color: #494440;
+  color: #f1f1f1;
 }
 
 .author-grid {


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Change the behavior when hovering the tags on articles, the colors are reversed.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #167 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It doesn't change anything code-wise, but it changes aesthetically the appearance of the tag when you hover it, which in my opinion is a little better in an experience POV.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox and Chrome.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5037407/51755113-29e10a80-20be-11e9-8cb8-f919018012fb.png)


## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (a non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
