### PR TITLE
[ISSUE-203] Change the default font size

### DIFF
--- a/_assets/css/post/post.css
+++ b/_assets/css/post/post.css
@@ -320,10 +320,6 @@ Description: Styles for articles / posts
     font-size: 3em;
   }
 
-  .article-content {
-    font-size: 1.3em;
-  }
-
   .article-categories {
     float: left;
     width: 80%;

--- a/_plugins/assets_tag.rb
+++ b/_plugins/assets_tag.rb
@@ -34,10 +34,10 @@ class AssetsSourceTag < Liquid::Tag
   end
 
   def load_manifest_file
-    return '' unless manifest?
+    return {} unless manifest?
 
     file = File.read MANIFEST_PATH
-    return '' unless file
+    return {} unless file
 
     Oj.load(file)
   end


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove the `1.3em` size for article contents.
Fix Assets tags plugin when no manifest exists.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #203

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The font size was too big on larger screens, we should try to maintain a 16px ration for font sizes (approx. 1em).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox and Chrome.

## Screenshots (if appropriate):
<img width="799" alt="image" src="https://user-images.githubusercontent.com/5037407/52165442-1c9ccf00-2701-11e9-9dc2-a72aa054a7b4.png">

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (a fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (a non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
