### PR TITLE
[ISSUE-216] Heroku build is failing with bundler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ rvm:
 before_install:
   - npm install
   - npm install -g gulp-cli
-  - gem install bundler:2.0.1
+  - gem install bundler:1.17.3
 
 install: bundle install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN apt-get clean \
 
 # Install the last bundler version
 # It is not available with the Heroku image
-RUN gem install bundler --no-document
+RUN gem install bundler:1.17.3 --no-document
 
 # Install Gulp
 RUN npm install --global gulp-cli

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -117,4 +117,4 @@ RUBY VERSION
    ruby 2.6.1p33
 
 BUNDLED WITH
-   2.0.1
+   1.17.3


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Downgrade bundler Ruby Gem to v1.17.3.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #216 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The Heroku buildpack for Ruby can't handle bundle to version >= 2.0.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
We can't really test until it is published to Heroku. I re-bundled using v1.17.3 and tested the build locally.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [x] Bug fix (a non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
