### PR TITLE
[ISSUE-234] Links to posts are broken since the markdown migration

### DIFF
--- a/_posts/2015-12-23-a-new-day.md
+++ b/_posts/2015-12-23-a-new-day.md
@@ -4,7 +4,7 @@ layout: post
 title: 'A new day'
 published_at: 2015-12-23T11:33:00+00:00
 categories: [Blog related]
-permalink: /:title
+permalink: /:title/
 author: jveillet
 summary: 'The new demain-il-pleut is open!'
 ---

--- a/_posts/2016-01-08-enabling-any-text-editor-with-git.md
+++ b/_posts/2016-01-08-enabling-any-text-editor-with-git.md
@@ -4,7 +4,7 @@ layout: post
 title: 'Enabling any text editor with git'
 published_at: 2016-01-08T15:58:00+00:00
 categories: [Git, editor, commit]
-permalink: /:title
+permalink: /:title/
 author: jveillet
 summary: 'How to enable any text editor to work with git commands'
 ---

--- a/_posts/2016-01-10-dealing-with-the-mongodb-error-datadb-not-found-in-osx.md
+++ b/_posts/2016-01-10-dealing-with-the-mongodb-error-datadb-not-found-in-osx.md
@@ -4,7 +4,7 @@ layout: post
 title: 'Dealing with the MongoDB error /data/db not found in OSX'
 published_at: 2016-01-10T10:50:00+00:00
 categories: [Code, Javascript, NoSQL]
-permalink: /:title
+permalink: /:title/
 author: jveillet
 summary: 'How to fix MongoDB error /data/db not found'
 ---

--- a/_posts/2016-01-19-introducing-first-draft-of-the-styleguide.md
+++ b/_posts/2016-01-19-introducing-first-draft-of-the-styleguide.md
@@ -4,7 +4,7 @@ layout: post
 title: 'Introducing first draft of the Styleguide'
 published_at: 2016-01-19T18:08:00+00:00
 categories: [Blog related, CSS]
-permalink: /:title
+permalink: /:title/
 author: jveillet
 ---
 

--- a/_posts/2016-01-21-how-to-clean-up-local-git-branches-matching-a-name.md
+++ b/_posts/2016-01-21-how-to-clean-up-local-git-branches-matching-a-name.md
@@ -4,7 +4,7 @@ layout: post
 title: 'How to clean up local git branches matching a name'
 published_at: 2016-01-21T18:00:00+00:00
 categories: [Git]
-permalink: /:title
+permalink: /:title/
 author: jveillet
 summary: 'How to clean your local Git branches'
 ---

--- a/_posts/2016-03-30-wordpress-development-environment-with-docker-part-i-installing-docker.md
+++ b/_posts/2016-03-30-wordpress-development-environment-with-docker-part-i-installing-docker.md
@@ -4,7 +4,7 @@ layout: post
 title: 'WordPress development environment with Docker Part I: installing Docker'
 published_at: 2016-03-30T16:44:00+00:00
 categories: [Code, Wordpress]
-permalink: /:title
+permalink: /:title/
 author: jveillet
 ---
 

--- a/_posts/2016-03-30-wordpress-development-environment-with-docker-part-ii-using-docker-compose-to-install-wordpress.md
+++ b/_posts/2016-03-30-wordpress-development-environment-with-docker-part-ii-using-docker-compose-to-install-wordpress.md
@@ -4,7 +4,7 @@ layout: post
 title: 'Wordpress development environment with Docker Part II: Using Docker Compose to install WordPress'
 published_at: 2016-03-30T17:12:00+00:00
 categories: [Code, Wordpress]
-permalink: /:title
+permalink: /:title/
 author: jveillet
 ---
 

--- a/_posts/2016-04-20-wordpress-development-environment-with-docker-part-iii-using-your-own-wordpress-theme.md
+++ b/_posts/2016-04-20-wordpress-development-environment-with-docker-part-iii-using-your-own-wordpress-theme.md
@@ -4,7 +4,7 @@ layout: post
 title: 'Wordpress Development Environment With Docker Part III Using Your Own Wordpress Theme'
 published_at: 2016-04-20T16:56:36+00:00
 categories: [Code, Wordpress]
-permalink: /:title
+permalink: /:title/
 author: jveillet
 ---
 

--- a/_posts/2017-01-30-deploy-slate-to-heroku.md
+++ b/_posts/2017-01-30-deploy-slate-to-heroku.md
@@ -4,7 +4,7 @@ layout: post
 title: 'Deploy Slate to Heroku'
 published_at: 2017-01-30T18:10:00+00:00
 categories: [Code, Ruby, Middleman, Heroku]
-permalink: /:title
+permalink: /:title/
 author: jveillet
 summary: 'Learn how to deploy the Slate documentation, and build the assets automatically on Heroku'
 ---

--- a/_posts/2018-07-17-saving-your-back-in-git.md
+++ b/_posts/2018-07-17-saving-your-back-in-git.md
@@ -4,7 +4,7 @@ layout: post
 title: 'Saving your back in git'
 published_at: 2018-07-17T18:00:00+00:00
 categories: [git, commands]
-permalink: /:title
+permalink: /:title/
 author: jveillet
 summary: 'Common situations with Git and how to resolve them'
 ---


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Change internal links on posts.
Add back the `/` on titles in the front matters.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #234 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
The links to posts were broken on Heroku since the migration to markdown posts.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested by modifying one article to see if that resolve the issue on Heroku, and then push the rest of the articles.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Improvement (a non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [x] Bug fix (a non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
