### PR TITLE
[ISSUE-295] Align Problem on tags for articles

### DIFF
--- a/_assets/css/post/post.css
+++ b/_assets/css/post/post.css
@@ -324,6 +324,17 @@ h2 .article-title:visited {
     margin-left: 3em;
   }
 
+  .article-tags-link:link,
+  .article-tags-link:visited {
+    background-color: #f1f1f1;
+    border-radius: 5%;
+    color: #494440 !important;
+    display: inline-block;
+    margin-top: 0;
+    padding: .5em;
+    text-decoration: none !important;
+  }
+
   .article-wrapper {
     margin: 0 auto;
   }

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -21,7 +21,7 @@ gulp.task('build:css', function() {
   return gulp.src(['_assets/css/**/*.css'])
         .pipe(sourcemaps.init())
         .pipe(cssnano())
-        .pipe( postcss([ autoprefixer({ browsers: ['last 4 versions'] }) ]) )
+        .pipe( postcss([ autoprefixer() ]) )
         .pipe(concat({path: 'bundle.min.css', cwd: ''}))
         .pipe(rev())
         .pipe(sourcemaps.write('.'))

--- a/package.json
+++ b/package.json
@@ -3,9 +3,13 @@
   "version": "2.4.0",
   "description": "Static demainilpleut.fr generated with Jekyll",
   "engines": {
-    "node": "10.15.0",
-    "npm": "6.7.0"
+    "node": "10.16.3",
+    "npm": "6.11.2"
   },
+  "browserslist": [
+    "last 4 version",
+    "> 2%"
+  ],
   "scripts": {
     "postinstall": "gulp build"
   },


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Fix align problem on the articles tags on the front page.
Fix warning issue in PostCSS Autoprefixer for the change of the browserlist configuration.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #295 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It fixes a UI problem where the tags seems not aligned with the author information on desktop mode.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5037407/64102366-142c7580-cd70-11e9-8b1b-697c8657cb9e.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
