### PR TITLE
[ISSUE-292] Boost menu bar links to 1em on desktop

### DIFF
--- a/_assets/css/topbar/topbar.css
+++ b/_assets/css/topbar/topbar.css
@@ -342,10 +342,6 @@ Description: Topbar styles
     margin: 1em .25em;
   }
 
-  .topbar-navigation-item {
-    font-size: .9em;
-  }
-
   .topbar-navigation-item,
   .topbar-navigation-item:visited {
     color: #4d4f56;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove the size of navigation links so that they appear at `1em`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #292 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Better legibility.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with Firefox.

## Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/5037407/64123551-f75e6500-cda4-11e9-9b55-f87cb35631b9.png)

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
