### PR TITLE
[ISSUE-375] Fix error 404 when installing apt packages

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -24,6 +24,7 @@ jobs:
         ruby-version: 2.6.x
     - name: Run Test Suite
       run: |
+        sudo apt update
         sudo apt-get -yqq install patch zlib1g-dev liblzma-dev libffi-dev libssl-dev libcurl4-gnutls-dev libxslt-dev
         gem install bundler --no-document
         bundle install


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Related to #/371, Fix Github Action CI step by introducing an `apt update` before doing and `apt install`.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #375 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If fixes the CI failing to retrieve Debian apt packages crashing the entire process.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested on Github.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Improvement (non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
