### PR TITLE
[ISSUE-397] Add smooth scrolling on back to top links

### DIFF
--- a/_assets/css/reset.css
+++ b/_assets/css/reset.css
@@ -153,6 +153,15 @@ body {
   -webkit-overflow-scrolling: touch;
 }
 
+@media screen and (prefers-reduced-motion: no-preference) {
+
+  html,
+  body {
+    scroll-behavior: smooth;
+  }
+
+}
+
 ol,
 ul {
   list-style: none;


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add smooth scrolling effect when a user clicks the "back to top" link.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #397 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This effect helps adding a little animation on scroll at barely not cost with a little CSS trick. The animation doesn't work if the user has explicitly set their OS to apply reduced motions. The only drawback is compatibility with older browsers.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with Firefox and Chrome.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
