### PR TITLE
[ISSUE-396] Add canonical URLS in HTML template headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # jk-demainilpleut
+
 [![Build Status](https://github.com/jveillet/jk-demainilpleut/workflows/CI/badge.svg)](https://github.com/jveillet/jk-demainilpleut/actions)
+[![Dependabot Status](https://api.dependabot.com/badges/status?host=github&repo=jveillet/jk-demainilpleut)](https://dependabot.com)
 
 Static HTML version of demainilpleut.fr using the static website generator
 [Jekyll](https://jekyllrb.com/).
@@ -13,6 +15,7 @@ JS.
 On the ruby side, this project uses [Bundler](https://bundler.io/).
 
 ### With Docker
+
 ```bash
 $ git clone git@github.com:jveillet/jk-demainilpleut.git
 $ cd jk-demainilpleut/
@@ -31,7 +34,6 @@ $ docker-compose run --rm web bundle exec jekyll serve -H 0.0.0.0 --incremental
 
 ### On linux (Debian 8+)
 
-Install nodejs and dependencies:
 ```bash
 # Add the latest node version to the sources
 $ curl -sL https://deb.nodesource.com/setup_10.x | bash - \
@@ -48,7 +50,6 @@ $ gulp lint
 
 ### On macOS (Sierra+)
 
-Install nodejs and dependencies:
 ```bash
 $ brew install node
 # Install Gulp
@@ -100,17 +101,21 @@ Basic tests are performed on the structure of the site (broken links, alt attrib
 They are launched automatically with every Pull Requests, via [GitHub Actions](https://help.github.com/en/github/automating-your-workflow-with-github-actions) (see [cibuild.yml](https://github.com/jveillet/jk-demainilpleut/blob/master/.github/workflows/cibuild.yml) file).
 
 You can run them manually via command line:
+
 ```bash
-$ ./bin/cibuild.sh
+./bin/cibuild.sh
 ```
 
 Or with Docker:
+
 ```bash
-$ docker-compose run --rm web bin/cibuild.sh
+docker-compose run --rm web bin/cibuild.sh
 ```
+
 ## Contributing
 
-## To the code
+### To the code
+
 This project only accepts Pull Requests that references an issue.
 
 1. Fork it ( http://github.com/jveillet/jk-demainilpleut/fork )
@@ -120,7 +125,8 @@ This project only accepts Pull Requests that references an issue.
 5. Push to the branch (git push origin my-new-feature)
 6. Create new Pull Request
 
-## To the articles
+### To the articles
+
 1. Fork it ( http://github.com/jveillet/jk-demainilpleut/fork )
 2. Create your feature branch for the new page (git checkout -b page/my-post-title)
 3. Create a post with the help of the command line: `bundle exec jekyll post "My post title"`, or a draft: `bundle exec jekyll draft "My post title"`

--- a/_data/authors.yml
+++ b/_data/authors.yml
@@ -2,7 +2,7 @@ jveillet:
   display: true
   name: Jérémie Veillet
   handle: jveillet
-  description: Jérémie is a french software developer from Nantes, France. he is currently working at Accenture, and he loves art in every shape and form.
+  description: Jérémie is a french software developer from La Rochelle, France. he is currently working at macompta.fr, and he loves art in every shape and form.
   avatar: https://avatars1.githubusercontent.com/u/5037407?v=3&s=460
   email: jveillet@users.noreply.github.com
   web:

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,6 +24,7 @@
   <meta name="twitter:card"  content="summary">
   {% endif %}
   <meta name="theme-color" content="#ffffff"/>
+  <link rel="canonical" href="{{ site.url }}{{ page.url | replace:'index.html', ''}}">
   <link href="{% link feed.xml %}" rel="alternate">
   <link media="screen" rel="stylesheet" href="{{ '/assets/css/bundle.min.css' | relative_url }}?{{ site.time | date: '%s%N' }}"/>
   <link media="screen" rel="stylesheet" href="{{ '/assets/css/vendor/prism.min.css' | relative_url }}"/>

--- a/bin/cibuild.sh
+++ b/bin/cibuild.sh
@@ -4,7 +4,7 @@
 set -e
 
 export NOKOGIRI_USE_SYSTEM_LIBRARIES=true
-export LANG=en_US.UTF-8
+export LANG=C.UTF-8
 
 # Buil the static site first
 bundle exec jekyll build --config _config.yml


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add dependabot badge on the README.
Add canonical URL in the default layout.
Fix for the cibuild script in local.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #396 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We plan to move to Netlify hosting before the end of the year, so let's lay down some foundation to facilitate the migration away from Heroku (and the .fr domain).

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
N/A

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
