### PR TITLE
[ISSUE-456] Update the canonical url to point to the .dev domain

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -8,6 +8,10 @@ description: Coding & Design for the rainy days
 # Used for Sitemap.xml and your RSS feed
 url: https://www.demainilpleut.fr
 
+# Canonical URL
+# See issue #456
+canonical_url: https://www.demainilpleut.dev
+
 # Your website logo (usefull for Twitter Cards)
 logo: assets/images/logo.png
 

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -24,7 +24,8 @@
   <meta name="twitter:card"  content="summary">
   {% endif %}
   <meta name="theme-color" content="#ffffff"/>
-  <link rel="canonical" href="{{ site.url }}{{ page.url | replace:'index.html', ''}}">
+  <meta name="color-scheme" content="dark light">
+  <link rel="canonical" href="{{ site.canonical_url }}{{ page.url | replace:'index.html', ''}}">
   <link href="{% link feed.xml %}" rel="alternate">
   <link media="screen" rel="stylesheet" href="{{ '/assets/css/bundle.min.css' | relative_url }}?{{ site.time | date: '%s%N' }}"/>
   <link media="screen" rel="stylesheet" href="{{ '/assets/css/vendor/prism.min.css' | relative_url }}"/>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Add a `canonical_url` property in to the Jekyll config.
Change the code for the canonical URL in the default layout to use the new porperty.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #456 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In an effort to move from Heroku to Netlify, this is another step towards that goal. When the website will be crawled again by search engines, and the URL will properly reflect the new domain, we will start deprecate the old environment.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested in Firefox and Chrome.

## Screenshots (if appropriate):
N/A

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
