### PR TITLE
[ISSUE-635] Remove scripts for html5shiv and picturefill

### DIFF
--- a/.github/workflows/cibuild.yml
+++ b/.github/workflows/cibuild.yml
@@ -15,12 +15,6 @@ jobs:
         node-version: 14.x
     - uses: actions/cache@v2
       with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-gems-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-gems-
-    - uses: actions/cache@v2
-      with:
         path: ~/.npm
         key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
         restore-keys: |
@@ -31,14 +25,13 @@ jobs:
         npm install --global gulp-cli
         gulp lint
     - name: Set up Ruby 2.7
-      uses: actions/setup-ruby@v1
+      uses: ruby/setup-ruby@v1
       with:
-        ruby-version: 2.7
+        bundler-cache: true
     - name: Run Test Suite
       run: |
         sudo apt update
         sudo apt-get -yqq install patch zlib1g-dev liblzma-dev libffi-dev libssl-dev libcurl4-gnutls-dev libxslt-dev
-        gem install bundler --no-document
         bundle config path vendor/bundle
         bundle install --jobs 4 --retry 3
         bin/cibuild.sh

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -66,8 +66,6 @@
       {% include footer.html %}
     </div><!-- end of wrapper -->
 
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv.min.js" defer></script>
-    <script src="https://cdnjs.cloudflare.com/ajax/libs/picturefill/3.0.3/picturefill.min.js" defer></script>
     <script src="{% link assets/js/vendor/prism.min.js %}" defer></script>
     <script src="{% link assets/js/vendor/a11y-toggle.min.js %}" defer></script>
     <script src="{% link assets/js/bundle.min.js %}?{{ site.time | date: '%s%N' }}" defer data-proofer-ignore></script>


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Remove picturefill dependency.
Remove html5shiv dependency.
Cleanup GitHub Action Workflow.

## Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first
-->
<!--- If fixing a bug, there should be an issue describing it with steps to
reproduce -->
<!--- Please link to the issue here: -->
closes #635 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
i think its safe now to drop support for old browsers and particularly Internet Explorer. Nice side effect: it will speed up page loads, and make the site lighter.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Tested with Firefox.

## Screenshots (if appropriate):

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the
boxes that apply: -->
- [ ] New feature (non-breaking change which adds functionality)
- [x] Improvement (non-breaking change which modifies functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to
  change)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that
apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to
help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
